### PR TITLE
Add Ayu Dark theme

### DIFF
--- a/colors/base16-ayu-dark.js
+++ b/colors/base16-ayu-dark.js
@@ -1,0 +1,43 @@
+// Base16 3024
+// Scheme: Jan T. Sott (http://github.com/idleberg)
+
+var color_scheme = {
+        'base00': '#0A0E14',
+        'base01': '#C2D94C',
+        'base02': '#FFB454',
+        'base03': '#626A73',
+        'base04': '#59C2FF',
+        'base05': '#CBCCC6',
+        'base06': '#FFEE99',
+        'base07': '#FFFFFF',
+        'base08': '#F07178',
+        'base09': '#F07178',
+        'base0A': '#FFB454',
+        'base0B': '#91B362',
+        'base0C': '#95E6CB',
+        'base0D': '#59C2FF',
+        'base0E': '#FFEE99',
+        'base0F': '#95E6CB',
+};
+
+term_.prefs_.set('background-color', color_scheme.base00);
+term_.prefs_.set('foreground-color', color_scheme.base05);
+term_.prefs_.set('cursor-color', "rgba(179, 177, 173)");
+
+term_.prefs_.set('color-palette-overrides',
+                        [color_scheme.base00,
+                        color_scheme.base08,
+                        color_scheme.base0B,
+                        color_scheme.base0A,
+                        color_scheme.base0D,
+                        color_scheme.base0E,
+                        color_scheme.base0C,
+                        color_scheme.base05,
+                        color_scheme.base03,
+                        color_scheme.base09,
+                        color_scheme.base01,
+                        color_scheme.base02,
+                        color_scheme.base04,
+                        color_scheme.base06,
+                        color_scheme.base0F,
+                        color_scheme.base07]);

--- a/colors/base16-ayu-dark.js
+++ b/colors/base16-ayu-dark.js
@@ -1,5 +1,8 @@
-// Base16 3024
-// Scheme: Jan T. Sott (http://github.com/idleberg)
+/* Base16 Ayu Dark
+   Created August 14, 2019
+   Ayu themes by: Ike Ku (https://github.com/dempfi)
+                  Boom Lee (https://github.com/teabyii)
+   Crosh port by: Luxray5474 (https://github.com/Luxray5474) */
 
 var color_scheme = {
         'base00': '#0A0E14',


### PR DESCRIPTION
note: this is how the Ayu Dark theme appears in VS Code, minus one color. Run `colortest` inside the VS Code integrated terminal using the Ayu Dark theme and the top two text colors are a bit darker than the right column. I cannot fit that color into the palette so when you run colortest in Crosh both that top text color and the rightmost column are the same color.